### PR TITLE
Neo4j2owl config schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 solr.json*
+venv
+.idea
+.DS_store
+__pycache__

--- a/config/prod/neo4j2owl_config_schema.json
+++ b/config/prod/neo4j2owl_config_schema.json
@@ -16,7 +16,7 @@
           "items": {
             "type": "string"
           },
-          "description": "A list of Manchester syntax class expressions in which OWL entities are expressed as curies."
+          "description": "A list of Manchester syntax class expressions in which OWL entities are expressed as CURIEs."
         },
         "label": {
           "description": "Semantic tag name",
@@ -54,7 +54,7 @@
       ]
     },
     "relation_type_threshold": {
-      "description": "neo2owl attempts to consistently cast annotation value types (property value types).  To do this is uses the threshold set here (more details TBA).",
+      "description": "neo2owl attempts to consistently cast annotation value types (property value types).  To do this it uses the threshold set here (more details TBA).",
       "type": "number"
     },
     "represent_values_and_annotations_as_json": {

--- a/config/prod/neo4j2owl_config_schema.json
+++ b/config/prod/neo4j2owl_config_schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "neo4j2owl-config schema",
+  "description": "A JSON schema for documenting and validating the neo4j2owl configuration YAML.",
+  "name": "neo4j2owl_config_schema",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "semantic_tag": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Specifies a set of Manchester syntax class expressions and a label. Annotates all entities that are equivalent_to or subclasses of these expression with the label using the AP: {TBA} .  In conversion to Neo4J these become neo4j:labels",
+      "properties": {
+        "classes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "A list of Manchester syntax class expressions in which OWL entities are expressed as curies."
+        },
+        "label": {
+          "description": "Semantic tag name",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "properties": {
+    "allow_entities_without_labels": {
+      "description": "Allow loading of entities without rdfs:label",
+      "type": "boolean"
+    },
+    "index": {
+      "description": "?",
+      "type": "boolean"
+    },
+    "testmode": {
+      "description": "?",
+      "type": "boolean"
+    },
+    "batch": {
+      "description": "Create and load CSVs in batches (?)",
+      "type": "boolean"
+    },
+    "batch_size": {
+      "description": "Size of batches to load",
+      "type": "integer"
+    },
+    "safe_label": {
+      "description": "?",
+      "type": "string",
+      "enum": [
+        "loose"
+      ]
+    },
+    "relation_type_threshold": {
+      "description": "neo2owl attempts to consistently cast annotation value types (property value types).  To do this is uses the threshold set here (more details TBA).",
+      "type": "number"
+    },
+    "represent_values_and_annotations_as_json": {
+      "description": "Use this to record the IRIs of annotation properties whose values should be recorded as JSON, allowing the representation of axiom annotations on annotation axioms.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "iris": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "neo_node_labelling": {
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/semantic_tag"
+        }
+      },
+    "curie_map": {
+      "description": "A map of prefixes to base IRIs.",
+      "type": "object",
+      "comment": "This could be improved."
+    },
+    "filters":{
+      "description": "",
+      "comment": "placeholder",
+      "type": "object"
+    }
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+ruamel.yaml
+jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-ruamel.yaml
-jsonschema
+ruamel.yaml==0.17.21
+jsonschema==4.4.0

--- a/src/schema_test_tools.py
+++ b/src/schema_test_tools.py
@@ -1,0 +1,106 @@
+import json
+from jsonschema import Draft4Validator, RefResolver, SchemaError
+import warnings
+import subprocess
+import os
+import glob
+from ruamel.yaml import YAML, YAMLError
+import warnings
+
+
+def get_json_from_file(filename):
+    """Loads json from a file.
+    """
+    f = open(filename, 'r')
+    fc = f.read()
+    f.close()
+    return json.loads(fc)
+
+def get_yaml_from_file(filename):
+    """Loads YAML from a file.
+    """
+    ryaml = YAML(typ='safe')
+    with open(filename) as stream:
+        try:
+            y = ryaml.load(stream)
+        except YAMLError as exc:
+            warnings.warn('Failed to open ' + filename + ' as YAML')
+    return y
+
+
+def get_validator(filename, base_uri=''):
+    """Load schema from JSON file;
+    Check whether it's a valid schema;
+    Return a Draft4Validator object.
+    Optionally specify a base URI for relative path
+    resolution of JSON pointers (This is especially useful
+    for local resolution via base_uri of form file://{some_path}/)
+    """
+
+    schema = get_json_from_file(filename)
+    try:
+        # Check schema via class method call. Works, despite IDE complaining
+        # However, it appears that this doesn't catch every schema issue.
+        Draft4Validator.check_schema(schema)
+        print("%s is a valid JSON schema" % filename)
+    except SchemaError:
+        raise
+    if base_uri:
+        resolver = RefResolver(base_uri=base_uri,
+                               referrer=filename)
+    else:
+        resolver = None
+    return Draft4Validator(schema=schema,
+                           resolver=resolver)
+
+
+def validate(validator, instance):
+    """Validate an instance of a schema and report errors."""
+    if validator.is_valid(instance):
+        print("Validation Passes")
+        return True
+    else:
+        es = validator.iter_errors(instance)
+        recurse_through_errors(es)
+        print("Validation Fails")
+        return False
+
+
+def recurse_through_errors(es, level=0):
+    """Recurse through errors posting message
+    and schema path until context is empty"""
+    # Assuming blank context is a sufficient escape clause here.
+    for e in es:
+        warnings.warn(
+            "***" * level + " subschema level " + str(level) + "\t".join([str(e.message),
+                                                                          "Path to error:" + str(
+                                                                              e.absolute_schema_path)]) + "\n")
+        if e.context:
+            level += 1
+            recurse_through_errors(e.context, level=level)
+
+
+def test_local(path_to_schema_dir, schema_file, test_dir, load_yaml=True):
+    """Tests all instances in a test_folder against a single schema.
+    Assumes all schema files in single dir.
+    Assumes all *.json files in the test_dir should validate against the schema.
+       * path_to_schema_dir:  Absolute or relative path to schema dir
+       * schema_file: schema file name
+       * test_dir: path to test directory (absolute or local to schema dir)
+    """
+    file_ext = 'json'
+    loader = get_json_from_file
+    if load_yaml:
+        file_ext = 'yaml'
+        loader = get_yaml_from_file
+#    os.chdir(path_to_schema_dir)
+    pwd = subprocess.check_output('pwd').decode("utf-8").rstrip()
+    # Removed resolver as this was causing failure of local path resolution.
+    # base_uri = "file://" + pwd + "/" + path_to_schema_dir
+    sv = get_validator(path_to_schema_dir + '/' + schema_file) #, base_uri)
+    test_files = glob.glob(pathname=test_dir + '/*.' + file_ext)
+    # print("Found test files: %s in %s" % (str(test_files), test_dir))
+    for instance_file in test_files:
+        i = loader(instance_file)
+        print("Testing: %s" % instance_file)
+        validate(sv, i)

--- a/src/schema_test_tools.py
+++ b/src/schema_test_tools.py
@@ -10,10 +10,13 @@ from pathlib import Path
 def get_json_from_file(filename):
     """Loads json from a file.
     """
-    f = open(filename, 'r')
-    fc = f.read()
-    f.close()
+    with open(filename, 'r') as f:
+        try:
+            fc = f.read()
+        except Exception as exc:
+            warnings.warn('Failed to open ' + filename + ' as JSON')
     return json.loads(fc)
+
 
 def get_yaml_from_file(filename):
     """Loads YAML from a file.
@@ -105,10 +108,9 @@ def test_local(path_to_schema_dir, schema_file, path_to_test_dir, load_yaml=True
         sv = get_validator(os.path.join(script_folder.parent, schema_dir, schema_file))
         test_dir_files = ''.join(['/*.', file_ext])
         test_files = glob.glob(pathname=os.path.join(script_folder.parent, test_dir) + test_dir_files)
-        # print("Found test files: %s in %s" % (str(test_files), path_to_test_dir))
+        print("Found test files: %s in %s" % (str(test_files), path_to_test_dir))
         for instance_file in test_files:
             print(instance_file)
             i = loader(instance_file)
             print("Testing: %s" % instance_file)
             validate(sv, i)
-

--- a/src/test_neo2owl_config.py
+++ b/src/test_neo2owl_config.py
@@ -1,0 +1,5 @@
+from schema_test_tools import test_local
+
+test_local(path_to_schema_dir='config/prod/',
+           schema_file='neo4j2owl_config_schema.json',
+           test_dir='config/prod/')

--- a/src/test_neo2owl_config.py
+++ b/src/test_neo2owl_config.py
@@ -2,4 +2,4 @@ from schema_test_tools import test_local
 
 test_local(path_to_schema_dir='config/prod/',
            schema_file='neo4j2owl_config_schema.json',
-           test_dir='config/prod/')
+           path_to_test_dir='config/prod/')


### PR DESCRIPTION
This PR contains a draft JSON schema for the neo4j2owl config which serves as both documentation of the config and a validator.

It can be run from `src/test_neo2owl_config.py`.  This should be hooked up to GitHub actions to test manual or programatic updated to the schema.

Note - while this works as basic doc + validator, some refactoring/re-organisation will be needed - both of this repo and its relationship to the core pipelines on the VFB org.   In particular, this schema really belongs on the core pipeline repo.

